### PR TITLE
Added watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,15 @@
                         "regexp": "TS(.*)",
                         "message": 1
                     }
-                ]
+                ],
+                "applyTo": "allDocuments",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "webpack: Compiling...",
+                    "endsPattern": {
+                        "regexp": "webpack: Failed to compile.|webpack: Compiled successfully."
+                    }
+                }
             },
             {
                 "name": "awesomets-lint",
@@ -52,7 +60,15 @@
                         "message": 3,
                         "loop": true
                     }
-                ]
+                ],
+                "applyTo": "allDocuments",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "webpack: Compiling...",
+                    "endsPattern": {
+                        "regexp": "webpack: Failed to compile.|webpack: Compiled successfully."
+                    }
+                }
             }
         ]
     },


### PR DESCRIPTION
If the task is marked as isBackground: true, these additions will show up errors in live compilation. 
Note: I've had a lot of negative experience with watching problem matchers, so unless there's a great benefit, be warned that this might not be a plug-n-play!